### PR TITLE
Update KDE SDK version to 6.8

### DIFF
--- a/org.fcitx.Fcitx5.Addon.McBopomofo.yaml
+++ b/org.fcitx.Fcitx5.Addon.McBopomofo.yaml
@@ -2,7 +2,7 @@ app-id: org.fcitx.Fcitx5.Addon.McBopomofo
 branch: stable
 runtime: org.fcitx.Fcitx5
 runtime-version: stable
-sdk: org.kde.Sdk//6.6
+sdk: org.kde.Sdk//6.8
 build-extension: true
 appstream-compose: false
 separate-locales: false
@@ -26,7 +26,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/fmtlib/fmt
-        tag: 9.1.0
+        tag: 11.0.2
     cleanup:
       - /include
       - /lib/cmake
@@ -58,5 +58,3 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DENABLE_TEST=Off
-    post-install:
-      - appstream-compose --basename=org.fcitx.Fcitx5.Addon.McBopomofo --prefix=${FLATPAK_DEST} --origin=flatpak org.fcitx.Fcitx5.Addon.McBopomofo


### PR DESCRIPTION
This is needed based on https://github.com/flathub/org.fcitx.Fcitx5/commit/6ddd6703eed02a19bfb86553dc3f9ccb8a16efad ; we have also received a report about our Flatpak package no longer usable with the latest fcitx5: https://github.com/openvanilla/fcitx5-mcbopomofo/issues/161

Also see other fcitx5 addon SDK version updates such as this one: https://github.com/flathub/org.fcitx.Fcitx5.Addon.Mozc/commit/e50a74852c833c8fb7194a7afd4a1c36eef37e00#diff-d7b3e43391b189c13b87214a984eb6e4c6fb04f6fce7de143b49717959a09b21L5
